### PR TITLE
Use correct width for codeblocks

### DIFF
--- a/development/11-helpfile-pdf-manual-header.tex
+++ b/development/11-helpfile-pdf-manual-header.tex
@@ -104,7 +104,7 @@
         {\ensuremath{\rhookswarrow}}},
     %breakatwhitespace=true,
     breakautoindent=true,
-    linewidth=\textwidth,
+    linewidth=\linewidth,
     xleftmargin=14pt,
     %xrightmargin=35pt,
 }

--- a/development/11-helpfile-pdf-manual-header.tex
+++ b/development/11-helpfile-pdf-manual-header.tex
@@ -104,7 +104,7 @@
         {\ensuremath{\rhookswarrow}}},
     %breakatwhitespace=true,
     breakautoindent=true,
-    linewidth=\linewidth,
+    linewidth=.95\linewidth,
     xleftmargin=14pt,
     %xrightmargin=35pt,
 }


### PR DESCRIPTION
The previous settings for the `listings` package use `\textwidth` as line width
but `\textwidth` is "The full horizontal width of the entire page body."
which is too large in (nested) lists. Therefore use `\linewidth` which is
always the width of the current environment for the `listings`
environment.

Tested by generating the German manual.

Fixes siduction/sidu-manual#44
